### PR TITLE
index: remove blog link

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,7 @@
                 <p>
                     Check out my
                     <a href="/about">about page</a>
-                    for a bit more about me, and my
-                    <a href="/blog">blog page</a>
-                    for my thoughts and ideas.
+                    for a bit more about me.
                 </p>
                 <div class="socials">
                     <a href="https://orcid.org/0000-0003-0115-0978">


### PR DESCRIPTION
We can leave the blog page itself there, but let's not link to it for now, because it just has “lorem ipsum” text, which at best will confuse visitors. We can link to the blog page when there's some content on it.